### PR TITLE
Modernize site layout with dark theme

### DIFF
--- a/donate/donate.html
+++ b/donate/donate.html
@@ -1,317 +1,55 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Donate - Populi Advocātiō</title>
-
-    <!-- Google Fonts -->
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
-
-    <!-- Import particles.js for background decoration -->
-    <script src="https://cdn.jsdelivr.net/particles.js/2.0.0/particles.min.js"></script>
-
-    <style>
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
-
-        body {
-            font-family: 'Inter', sans-serif;
-            background-color: #f4f4f9;
-            color: #333;
-            line-height: 1.6;
-            margin: 0;
-            padding: 0;
-            scroll-behavior: smooth;
-            position: relative;
-            overflow-x: hidden;
-        }
-
-        /* Particle.js Background */
-        #particles-js {
-            position: fixed;
-            top: 100vh;
-            width: 100%;
-            height: 100vh;
-            z-index: -1;
-        }
-
-        /* Navbar */
-        .navbar {
-            background-color: #ffffff;
-            padding: 20px;
-            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-            position: fixed;
-            width: 100%;
-            top: 0;
-            z-index: 1000;
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-        }
-
-        .navbar a {
-            color: #333;
-            text-decoration: none;
-            margin: 0 15px;
-            font-size: 1.1em;
-            font-weight: 600;
-            transition: color 0.3s ease;
-        }
-
-        .navbar a:hover {
-            color: #007BFF;
-        }
-
-        /* Hero Section */
-        .hero {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            height: 100vh;
-            background-color: #e8eaf6;
-            text-align: center;
-            padding: 0 20px;
-            position: relative;
-        }
-
-        .hero h1 {
-            font-size: 3.5em;
-            color: #333;
-            font-weight: 800;
-            margin-bottom: 20px;
-        }
-
-        .hero p {
-            font-size: 1.2em;
-            color: #666;
-            margin-bottom: 30px;
-        }
-
-        .hero button {
-            background-color: #007BFF;
-            color: #fff;
-            padding: 15px 30px;
-            border: none;
-            border-radius: 5px;
-            cursor: pointer;
-            font-size: 1.1em;
-            transition: background-color 0.3s ease;
-        }
-
-        .hero button:hover {
-            background-color: #0056b3;
-        }
-
-        /* Section Styling */
-        .section {
-            padding: 60px 20px;
-            text-align: center;
-        }
-
-        .section h2 {
-            font-size: 2.5em;
-            color: #333;
-            margin-bottom: 20px;
-            font-weight: 800;
-        }
-
-        .section p {
-            font-size: 1.2em;
-            color: #666;
-            max-width: 800px;
-            margin: 0 auto;
-        }
-
-        /* Donation Section */
-        .donation-section {
-            display: flex;
-            justify-content: space-around;
-            flex-wrap: wrap;
-            gap: 20px;
-            max-width: 1100px;
-            margin: 40px auto;
-        }
-
-        .donation-card {
-            background-color: #ffffff;
-            padding: 40px;
-            border-radius: 10px;
-            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-            text-align: center;
-            width: 45%;
-            transition: transform 0.3s ease;
-        }
-
-        .donation-card:hover {
-            transform: translateY(-10px);
-            box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
-        }
-
-        .donation-card h3 {
-            font-size: 1.8em;
-            margin-bottom: 15px;
-            color: #333;
-            font-weight: 600;
-        }
-
-        .donation-card p {
-            font-size: 1em;
-            color: #666;
-        }
-
-        .donation-address {
-            font-weight: bold;
-            color: #007BFF;
-            cursor: pointer;
-            transition: color 0.3s ease;
-        }
-
-        .donation-address:hover {
-            color: #0056b3;
-        }
-
-        /* Footer */
-        .footer {
-            background-color: #333;
-            color: #ffffff;
-            padding: 40px 20px;
-            text-align: center;
-        }
-
-        .footer a {
-            color: #ffffff;
-            text-decoration: none;
-            margin: 0 10px;
-            font-size: 1.1em;
-        }
-
-        .footer a:hover {
-            color: #007BFF;
-        }
-
-        .footer p {
-            font-size: 0.9em;
-            margin-top: 20px;
-        }
-
-    </style>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Donate - Populi Advocātiō</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../style.css">
 </head>
 <body>
-
-    <!-- Particle.js Background -->
-    <div id="particles-js"></div>
-
-    <!-- Navbar -->
-    <div class="navbar">
-        <div>
-            <a href="https://apgo.ink">Home</a>
-            <a href="https://apgo.ink/contactus" target="_blank">Contact</a>
-        </div>
+  <nav>
+    <div class="logo"><a href="../" style="color:inherit;text-decoration:none">Populi Advocātiō</a></div>
+    <div class="links">
+      <a href="../">Home</a>
+      <a href="../contactus" target="_blank">Contact</a>
+      <button class="theme-toggle">Toggle Theme</button>
     </div>
-
-    <!-- Hero Section -->
-    <div class="hero">
-        <div>
-            <h1>Support Our Mission</h1>
-            <p>Your contributions help us continue providing valuable insights and research.</p>
-        </div>
+  </nav>
+  <section class="hero">
+    <h1>Support Our Mission</h1>
+    <p>Your contributions help us continue providing valuable insights and research.</p>
+  </section>
+  <section class="section fade-up">
+    <h2>Make a Donation</h2>
+    <p>Support Populi Advocātiō using cryptocurrency. Click any address to copy it.</p>
+    <div class="cards">
+      <div class="card" onclick="copyToClipboard('bc1qvu4q326jhrjt8cdnhuz7xx2nvckqfxzenz70cu')">
+        <h3>Bitcoin</h3>
+        <p class="donation-address">bc1qvu4q326jhrjt8cdnhuz7xx2nvckqfxzenz70cu</p>
+      </div>
+      <div class="card" onclick="copyToClipboard('0x7CCB96AA9221AAE4FC8C015a35515c4395bd0dD4')">
+        <h3>Ethereum</h3>
+        <p class="donation-address">0x7CCB96AA9221AAE4FC8C015a35515c4395bd0dD4</p>
+      </div>
+      <div class="card" onclick="copyToClipboard('r9kf8WVDj9WJnDYsvFqBtgMrgSswpssoCi')">
+        <h3>XRP</h3>
+        <p class="donation-address">r9kf8WVDj9WJnDYsvFqBtgMrgSswpssoCi</p>
+      </div>
     </div>
-
-    <!-- Donation Section -->
-    <section class="section">
-        <h2>Make a Donation</h2>
-        <p>You can support Populi Advocātiō using any of the following cryptocurrency options. Click on any address to copy it to your clipboard.</p>
-        
-        <div class="donation-section">
-            <div class="donation-card">
-                <h3>Bitcoin</h3>
-                <p class="donation-address" onclick="copyToClipboard('bc1qvu4q326jhrjt8cdnhuz7xx2nvckqfxzenz70cu')">bc1qvu4q326jhrjt8cdnhuz7xx2nvckqfxzenz70cu</p>
-            </div>
-            <div class="donation-card">
-                <h3>Ethereum</h3>
-                <p class="donation-address" onclick="copyToClipboard('0x7CCB96AA9221AAE4FC8C015a35515c4395bd0dD4')">0x7CCB96AA9221AAE4FC8C015a35515c4395bd0dD4</p>
-            </div>
-            <div class="donation-card">
-                <h3>XRP</h3>
-                <p class="donation-address" onclick="copyToClipboard('r9kf8WVDj9WJnDYsvFqBtgMrgSswpssoCi')">r9kf8WVDj9WJnDYsvFqBtgMrgSswpssoCi</p>
-            </div>
-        </div>
-    </section>
-
-    <!-- Footer -->
-    <div class="footer">
-        <a href="https://apgo.ink/contactus" target="_blank">Contact Us</a>
-        <p>&copy; 2024 Populi Advocātiō. All rights reserved.</p>
-    </div>
-
-    <!-- JavaScript -->
-    <script>
-        // Function to copy address to clipboard
-        function copyToClipboard(text) {
-            navigator.clipboard.writeText(text).then(() => {
-                alert("Address copied to clipboard!");
-            }).catch(err => {
-                console.log('Something went wrong', err);
-            });
-        }
-
-        // Particles.js background decoration
-        particlesJS('particles-js', {
-            "particles": {
-                "number": {
-                    "value": 80,
-                    "density": {
-                        "enable": true,
-                        "value_area": 800
-                    }
-                },
-                "color": {
-                    "value": "#ffffff"
-                },
-                "shape": {
-                    "type": "circle",
-                    "stroke": {
-                        "width": 0,
-                        "color": "#000000"
-                    }
-                },
-                "opacity": {
-                    "value": 0.5,
-                    "random": false
-                },
-                "size": {
-                    "value": 5,
-                    "random": true
-                },
-                "line_linked": {
-                    "enable": true,
-                    "distance": 150,
-                    "color": "#ffffff",
-                    "opacity": 0.4,
-                    "width": 1
-                },
-                "move": {
-                    "enable": true,
-                    "speed": 6,
-                    "direction": "none",
-                    "random": false,
-                    "straight": false,
-                    "out_mode": "out",
-                    "bounce": false,
-                    "attract": {
-                        "enable": false,
-                        "rotateX": 600,
-                        "rotateY": 1200
-                    }
-                }
-            },
-            "retina_detect": true
-        });
-    </script>
-
+  </section>
+  <footer>
+    <a href="../">Home</a>
+    <a href="../tos" target="_blank">Terms of Service</a>
+    <a href="../pp" target="_blank">Privacy Policy</a>
+    <a href="../contactus" target="_blank">Contact Us</a>
+    <p>&copy; 2024 Populi Advocātiō. All rights reserved.</p>
+  </footer>
+  <script src="../theme.js"></script>
+  <script>
+    function copyToClipboard(text){
+      navigator.clipboard.writeText(text).then(()=>alert('Address copied to clipboard!'));
+    }
+  </script>
 </body>
 </html>

--- a/donation/index.html
+++ b/donation/index.html
@@ -1,317 +1,55 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Donate - Populi Advocātiō</title>
-
-    <!-- Google Fonts -->
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
-
-    <!-- Import particles.js for background decoration -->
-    <script src="https://cdn.jsdelivr.net/particles.js/2.0.0/particles.min.js"></script>
-
-    <style>
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
-
-        body {
-            font-family: 'Inter', sans-serif;
-            background-color: #f4f4f9;
-            color: #333;
-            line-height: 1.6;
-            margin: 0;
-            padding: 0;
-            scroll-behavior: smooth;
-            position: relative;
-            overflow-x: hidden;
-        }
-
-        /* Particle.js Background */
-        #particles-js {
-            position: fixed;
-            top: 100vh;
-            width: 100%;
-            height: 100vh;
-            z-index: -1;
-        }
-
-        /* Navbar */
-        .navbar {
-            background-color: #ffffff;
-            padding: 20px;
-            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-            position: fixed;
-            width: 100%;
-            top: 0;
-            z-index: 1000;
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-        }
-
-        .navbar a {
-            color: #333;
-            text-decoration: none;
-            margin: 0 15px;
-            font-size: 1.1em;
-            font-weight: 600;
-            transition: color 0.3s ease;
-        }
-
-        .navbar a:hover {
-            color: #007BFF;
-        }
-
-        /* Hero Section */
-        .hero {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            height: 100vh;
-            background-color: #e8eaf6;
-            text-align: center;
-            padding: 0 20px;
-            position: relative;
-        }
-
-        .hero h1 {
-            font-size: 3.5em;
-            color: #333;
-            font-weight: 800;
-            margin-bottom: 20px;
-        }
-
-        .hero p {
-            font-size: 1.2em;
-            color: #666;
-            margin-bottom: 30px;
-        }
-
-        .hero button {
-            background-color: #007BFF;
-            color: #fff;
-            padding: 15px 30px;
-            border: none;
-            border-radius: 5px;
-            cursor: pointer;
-            font-size: 1.1em;
-            transition: background-color 0.3s ease;
-        }
-
-        .hero button:hover {
-            background-color: #0056b3;
-        }
-
-        /* Section Styling */
-        .section {
-            padding: 60px 20px;
-            text-align: center;
-        }
-
-        .section h2 {
-            font-size: 2.5em;
-            color: #333;
-            margin-bottom: 20px;
-            font-weight: 800;
-        }
-
-        .section p {
-            font-size: 1.2em;
-            color: #666;
-            max-width: 800px;
-            margin: 0 auto;
-        }
-
-        /* Donation Section */
-        .donation-section {
-            display: flex;
-            justify-content: space-around;
-            flex-wrap: wrap;
-            gap: 20px;
-            max-width: 1100px;
-            margin: 40px auto;
-        }
-
-        .donation-card {
-            background-color: #ffffff;
-            padding: 40px;
-            border-radius: 10px;
-            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-            text-align: center;
-            width: 45%;
-            transition: transform 0.3s ease;
-        }
-
-        .donation-card:hover {
-            transform: translateY(-10px);
-            box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
-        }
-
-        .donation-card h3 {
-            font-size: 1.8em;
-            margin-bottom: 15px;
-            color: #333;
-            font-weight: 600;
-        }
-
-        .donation-card p {
-            font-size: 1em;
-            color: #666;
-        }
-
-        .donation-address {
-            font-weight: bold;
-            color: #007BFF;
-            cursor: pointer;
-            transition: color 0.3s ease;
-        }
-
-        .donation-address:hover {
-            color: #0056b3;
-        }
-
-        /* Footer */
-        .footer {
-            background-color: #333;
-            color: #ffffff;
-            padding: 40px 20px;
-            text-align: center;
-        }
-
-        .footer a {
-            color: #ffffff;
-            text-decoration: none;
-            margin: 0 10px;
-            font-size: 1.1em;
-        }
-
-        .footer a:hover {
-            color: #007BFF;
-        }
-
-        .footer p {
-            font-size: 0.9em;
-            margin-top: 20px;
-        }
-
-    </style>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Donate - Populi Advocātiō</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../style.css">
 </head>
 <body>
-
-    <!-- Particle.js Background -->
-    <div id="particles-js"></div>
-
-    <!-- Navbar -->
-    <div class="navbar">
-        <div>
-            <a href="https://apgo.ink">Home</a>
-            <a href="https://apgo.ink/contactus" target="_blank">Contact</a>
-        </div>
+  <nav>
+    <div class="logo"><a href="../" style="color:inherit;text-decoration:none">Populi Advocātiō</a></div>
+    <div class="links">
+      <a href="../">Home</a>
+      <a href="../contactus" target="_blank">Contact</a>
+      <button class="theme-toggle">Toggle Theme</button>
     </div>
-
-    <!-- Hero Section -->
-    <div class="hero">
-        <div>
-            <h1>Support Our Mission</h1>
-            <p>Your contributions help us continue providing valuable insights and research.</p>
-        </div>
+  </nav>
+  <section class="hero">
+    <h1>Support Our Mission</h1>
+    <p>Your contributions help us continue providing valuable insights and research.</p>
+  </section>
+  <section class="section fade-up">
+    <h2>Make a Donation</h2>
+    <p>Support Populi Advocātiō using cryptocurrency. Click any address to copy it.</p>
+    <div class="cards">
+      <div class="card" onclick="copyToClipboard('bc1qvu4q326jhrjt8cdnhuz7xx2nvckqfxzenz70cu')">
+        <h3>Bitcoin</h3>
+        <p class="donation-address">bc1qvu4q326jhrjt8cdnhuz7xx2nvckqfxzenz70cu</p>
+      </div>
+      <div class="card" onclick="copyToClipboard('0x7CCB96AA9221AAE4FC8C015a35515c4395bd0dD4')">
+        <h3>Ethereum</h3>
+        <p class="donation-address">0x7CCB96AA9221AAE4FC8C015a35515c4395bd0dD4</p>
+      </div>
+      <div class="card" onclick="copyToClipboard('r9kf8WVDj9WJnDYsvFqBtgMrgSswpssoCi')">
+        <h3>XRP</h3>
+        <p class="donation-address">r9kf8WVDj9WJnDYsvFqBtgMrgSswpssoCi</p>
+      </div>
     </div>
-
-    <!-- Donation Section -->
-    <section class="section">
-        <h2>Make a Donation</h2>
-        <p>You can support Populi Advocātiō using any of the following cryptocurrency options. Click on any address to copy it to your clipboard.</p>
-        
-        <div class="donation-section">
-            <div class="donation-card">
-                <h3>Bitcoin</h3>
-                <p class="donation-address" onclick="copyToClipboard('bc1qvu4q326jhrjt8cdnhuz7xx2nvckqfxzenz70cu')">bc1qvu4q326jhrjt8cdnhuz7xx2nvckqfxzenz70cu</p>
-            </div>
-            <div class="donation-card">
-                <h3>Ethereum</h3>
-                <p class="donation-address" onclick="copyToClipboard('0x7CCB96AA9221AAE4FC8C015a35515c4395bd0dD4')">0x7CCB96AA9221AAE4FC8C015a35515c4395bd0dD4</p>
-            </div>
-            <div class="donation-card">
-                <h3>XRP</h3>
-                <p class="donation-address" onclick="copyToClipboard('r9kf8WVDj9WJnDYsvFqBtgMrgSswpssoCi')">r9kf8WVDj9WJnDYsvFqBtgMrgSswpssoCi</p>
-            </div>
-        </div>
-    </section>
-
-    <!-- Footer -->
-    <div class="footer">
-        <a href="https://apgo.ink/contactus" target="_blank">Contact Us</a>
-        <p>&copy; 2024 Populi Advocātiō. All rights reserved.</p>
-    </div>
-
-    <!-- JavaScript -->
-    <script>
-        // Function to copy address to clipboard
-        function copyToClipboard(text) {
-            navigator.clipboard.writeText(text).then(() => {
-                alert("Address copied to clipboard!");
-            }).catch(err => {
-                console.log('Something went wrong', err);
-            });
-        }
-
-        // Particles.js background decoration
-        particlesJS('particles-js', {
-            "particles": {
-                "number": {
-                    "value": 80,
-                    "density": {
-                        "enable": true,
-                        "value_area": 800
-                    }
-                },
-                "color": {
-                    "value": "#ffffff"
-                },
-                "shape": {
-                    "type": "circle",
-                    "stroke": {
-                        "width": 0,
-                        "color": "#000000"
-                    }
-                },
-                "opacity": {
-                    "value": 0.5,
-                    "random": false
-                },
-                "size": {
-                    "value": 5,
-                    "random": true
-                },
-                "line_linked": {
-                    "enable": true,
-                    "distance": 150,
-                    "color": "#ffffff",
-                    "opacity": 0.4,
-                    "width": 1
-                },
-                "move": {
-                    "enable": true,
-                    "speed": 6,
-                    "direction": "none",
-                    "random": false,
-                    "straight": false,
-                    "out_mode": "out",
-                    "bounce": false,
-                    "attract": {
-                        "enable": false,
-                        "rotateX": 600,
-                        "rotateY": 1200
-                    }
-                }
-            },
-            "retina_detect": true
-        });
-    </script>
-
+  </section>
+  <footer>
+    <a href="../">Home</a>
+    <a href="../tos" target="_blank">Terms of Service</a>
+    <a href="../pp" target="_blank">Privacy Policy</a>
+    <a href="../contactus" target="_blank">Contact Us</a>
+    <p>&copy; 2024 Populi Advocātiō. All rights reserved.</p>
+  </footer>
+  <script src="../theme.js"></script>
+  <script>
+    function copyToClipboard(text){
+      navigator.clipboard.writeText(text).then(()=>alert('Address copied to clipboard!'));
+    }
+  </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,192 +1,90 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Populi Advocātiō</title>
-    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;800&display=swap" rel="stylesheet">
-    <style>
-        :root {
-            --primary: #007BFF;
-            --secondary: #6C63FF;
-            --light-bg: #f5f7fa;
-        }
-        * { margin: 0; padding: 0; box-sizing: border-box; }
-        body {
-            font-family: 'Poppins', sans-serif;
-            background: var(--light-bg);
-            color: #333;
-            line-height: 1.6;
-        }
-        nav {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            padding: 15px 30px;
-            background: #fff;
-            box-shadow: 0 4px 10px rgba(0,0,0,0.05);
-            position: fixed;
-            width: 100%;
-            top: 0;
-            z-index: 1000;
-        }
-        nav .links a {
-            margin: 0 15px;
-            color: #333;
-            text-decoration: none;
-            font-weight: 600;
-        }
-        nav .links a:hover { color: var(--primary); }
-        .hero {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            text-align: center;
-            height: 100vh;
-            background: linear-gradient(135deg,var(--primary),var(--secondary));
-            color: #fff;
-            flex-direction: column;
-            padding: 0 20px;
-        }
-        .hero h1 { font-size: 4em; margin-bottom: 10px; font-weight: 800; }
-        .hero p { font-size: 1.4em; margin-bottom: 25px; }
-        .hero .btn {
-            padding: 12px 28px;
-            background: #fff;
-            color: var(--primary);
-            border: none;
-            border-radius: 5px;
-            font-size: 1.1em;
-            cursor: pointer;
-            transition: background .3s;
-            text-decoration: none;
-        }
-        .hero .btn:hover { background: #0056b3; color: #fff; }
-        .section { padding: 80px 20px; text-align: center; }
-        .section h2 { font-size: 2.6em; margin-bottom: 20px; color: #333; font-weight: 800; }
-        .section p { font-size: 1.2em; color: #666; max-width: 800px; margin: 0 auto; }
-        .cards { display: flex; justify-content: center; gap: 25px; flex-wrap: wrap; max-width: 1100px; margin: 40px auto; }
-        .card {
-            background: #fff;
-            padding: 40px;
-            border-radius: 8px;
-            box-shadow: 0 4px 12px rgba(0,0,0,0.05);
-            width: 45%;
-            max-width: 500px;
-            text-align: center;
-            transition: transform .3s, box-shadow .3s;
-            cursor: pointer;
-        }
-        .card:hover { transform: translateY(-8px); box-shadow: 0 6px 20px rgba(0,0,0,0.1); }
-        .card h3 { font-size: 1.8em; margin-bottom: 10px; color: #333; font-weight: 600; }
-        .card p { color: #666; font-size: 1em; }
-        .resources { background: var(--light-bg); padding: 60px 20px; }
-        .resource-card {
-            display: flex;
-            align-items: center;
-            gap: 20px;
-            background: #fff;
-            border-radius: 10px;
-            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
-            padding: 20px;
-            text-decoration: none;
-            color: #333;
-            max-width: 700px;
-            margin: 10px auto;
-        }
-        .resource-card img { width: 100px; height: 100px; border-radius: 10px; }
-        .resource-card .icon-box {
-            width: 100px; height: 100px;
-            display: flex; align-items: center; justify-content: center;
-            font-size: 2em; font-weight: 800; border-radius: 10px; color: #fff;
-        }
-        .dictionary-icon{ background: #e0e7ff; color: var(--primary); }
-        .culture-icon{ background: #4caf50; }
-        .cuisine-icon{ background: #ff5722; }
-        .beverage-icon{ background: #2196f3; }
-        footer { background: #333; color: #fff; padding: 40px 20px; text-align: center; }
-        footer a { color: #fff; text-decoration: none; margin: 0 10px; }
-        footer a:hover { color: var(--secondary); }
-        footer p { margin-top: 20px; font-size: .9em; }
-    </style>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Populi Advocātiō</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <nav>
-        <div class="logo">Populi Advocātiō</div>
-        <div class="links">
-            <a href="#mission">Mission</a>
-            <a href="#services">Services</a>
-            <a href="#resources">Resources</a>
-            <a href="https://apgo.ink/contactus" target="_blank">Contact</a>
-        </div>
-    </nav>
-    <section class="hero">
-        <h1>Populi Advocātiō</h1>
-        <p>Advocating for the people.</p>
-        <a class="btn" href="https://apgo.ink/aboutus">Learn More</a>
-    </section>
-    <section id="mission" class="section">
-        <h2>Our Mission</h2>
-        <p>Bringing humanity one step closer to global peace and universal education, through advocacy.</p>
-    </section>
-    <section id="services" class="section">
-        <h2>Our Services</h2>
-        <div class="cards">
-            <div class="card" onclick="window.location.href='https://apgo.ink/journal'">
-                <h3>Journalism</h3>
-                <p>In-depth investigations into critical global events and their impact on society.</p>
-            </div>
-            <div class="card" onclick="window.location.href='https://apgo.ink/intelligence'">
-                <h3>Intelligence</h3>
-                <p>Analyzing global data to inform decisions and reveal potential risks.</p>
-            </div>
-        </div>
-    </section>
-    <section id="resources" class="resources">
-        <h2>Resources</h2>
-        <p class="resource-intro">Explore our curated resources designed to educate and inform you about the world.</p>
-        <a href="https://apgo.ink/basilisk" class="resource-card" target="_blank">
-            <img src="basiliskicon.png" alt="Basilisk Logo">
-            <div>
-                <h3>Basilisk App (Coming Soon)</h3>
-                <p>An all-in-one platform prioritizing user privacy.</p>
-            </div>
-        </a>
-        <a href="https://apgo.ink/dictionary" class="resource-card" target="_blank">
-            <div class="icon-box dictionary-icon">D</div>
-            <div>
-                <h3>Dictionary</h3>
-                <p>A comprehensive dictionary for words in the English language.</p>
-            </div>
-        </a>
-        <a href="https://apgo.ink/cultures" class="resource-card" target="_blank">
-            <div class="icon-box culture-icon">CE</div>
-            <div>
-                <h3>Culture Explorer</h3>
-                <p>Learn about cultures around the world and their unique characteristics.</p>
-            </div>
-        </a>
-        <a href="https://apgo.ink/cuisines" class="resource-card" target="_blank">
-            <div class="icon-box cuisine-icon">C</div>
-            <div>
-                <h3>Cuisines from Around the World</h3>
-                <p>Explore extensive information about global cuisines and culinary traditions.</p>
-            </div>
-        </a>
-        <a href="https://apgo.ink/beverages" class="resource-card" target="_blank">
-            <div class="icon-box beverage-icon">B</div>
-            <div>
-                <h3>Beverages from Around the World</h3>
-                <p>Discover a wide range of beverages from various cultures and their origins.</p>
-            </div>
-        </a>
-    </section>
-    <footer>
-        <a href="https://apgo.ink/donation" target="_blank">Donate</a>
-        <a href="https://apgo.ink/tos" target="_blank">Terms of Service</a>
-        <a href="https://apgo.ink/pp" target="_blank">Privacy Policy</a>
-        <a href="https://apgo.ink/contactus" target="_blank">Contact Us</a>
-        <p>&copy; 2024 Populi Advocātiō. All rights reserved.</p>
-    </footer>
+  <nav>
+    <div class="logo">Populi Advocātiō</div>
+    <div class="links">
+      <a href="#mission">Mission</a>
+      <a href="#services">Services</a>
+      <a href="#resources">Resources</a>
+      <a href="https://apgo.ink/contactus" target="_blank">Contact</a>
+      <button class="theme-toggle">Toggle Theme</button>
+    </div>
+  </nav>
+  <section class="hero">
+    <h1>Populi Advocātiō</h1>
+    <p>Advocating for the people through transparent journalism and research.</p>
+    <a class="theme-toggle" href="#mission">Explore</a>
+  </section>
+  <section id="mission" class="section fade-up">
+    <h2>Our Mission</h2>
+    <p>Bringing humanity closer to global peace and universal education through advocacy.</p>
+  </section>
+  <section id="services" class="section fade-up">
+    <h2>Our Services</h2>
+    <div class="cards">
+      <div class="card" onclick="location.href='https://apgo.ink/journal'">
+        <h3>Journalism</h3>
+        <p>Investigations into critical global events and their societal impact.</p>
+      </div>
+      <div class="card" onclick="location.href='https://apgo.ink/intelligence'">
+        <h3>Intelligence</h3>
+        <p>Analyzing data to inform decisions and reveal potential risks.</p>
+      </div>
+    </div>
+  </section>
+  <section id="resources" class="section fade-up">
+    <h2>Resources</h2>
+    <a href="https://apgo.ink/basilisk" class="resource-card" target="_blank">
+      <img src="basiliskicon.png" alt="Basilisk logo">
+      <div>
+        <h3>Basilisk App (Coming Soon)</h3>
+        <p>An all-in-one platform prioritizing user privacy.</p>
+      </div>
+    </a>
+    <a href="https://apgo.ink/dictionary" class="resource-card" target="_blank">
+      <div class="icon-box" style="background:#e0e7ff;color:#0a84ff;display:flex;align-items:center;justify-content:center;font-weight:700;">D</div>
+      <div>
+        <h3>Dictionary</h3>
+        <p>A comprehensive dictionary for words in the English language.</p>
+      </div>
+    </a>
+    <a href="https://apgo.ink/cultures" class="resource-card" target="_blank">
+      <div class="icon-box" style="background:#4caf50;display:flex;align-items:center;justify-content:center;font-weight:700;">CE</div>
+      <div>
+        <h3>Culture Explorer</h3>
+        <p>Learn about cultures around the world and their unique characteristics.</p>
+      </div>
+    </a>
+    <a href="https://apgo.ink/cuisines" class="resource-card" target="_blank">
+      <div class="icon-box" style="background:#ff5722;display:flex;align-items:center;justify-content:center;font-weight:700;">C</div>
+      <div>
+        <h3>Cuisines</h3>
+        <p>Explore information about global cuisines and culinary traditions.</p>
+      </div>
+    </a>
+    <a href="https://apgo.ink/beverages" class="resource-card" target="_blank">
+      <div class="icon-box" style="background:#2196f3;display:flex;align-items:center;justify-content:center;font-weight:700;">B</div>
+      <div>
+        <h3>Beverages</h3>
+        <p>Discover beverages from various cultures and their origins.</p>
+      </div>
+    </a>
+  </section>
+  <footer>
+    <a href="https://apgo.ink/donation" target="_blank">Donate</a>
+    <a href="https://apgo.ink/tos" target="_blank">Terms of Service</a>
+    <a href="https://apgo.ink/pp" target="_blank">Privacy Policy</a>
+    <a href="https://apgo.ink/contactus" target="_blank">Contact Us</a>
+    <p>&copy; 2024 Populi Advocātiō. All rights reserved.</p>
+  </footer>
+  <script src="theme.js"></script>
 </body>
 </html>

--- a/pp/index.html
+++ b/pp/index.html
@@ -1,271 +1,45 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Privacy Policy - Populi Advocātiō</title>
-
-    <!-- Google Fonts -->
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
-
-    <!-- Import particles.js for background decoration -->
-    <script src="https://cdn.jsdelivr.net/particles.js/2.0.0/particles.min.js"></script>
-
-    <style>
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
-
-        body {
-            font-family: 'Inter', sans-serif;
-            background-color: #f4f4f9;
-            color: #333;
-            line-height: 1.6;
-            margin: 0;
-            padding: 0;
-            scroll-behavior: smooth;
-            position: relative;
-            overflow-x: hidden;
-        }
-
-        /* Particle.js Background */
-        #particles-js {
-            position: fixed;
-            top: 100vh;
-            width: 100%;
-            height: 100vh;
-            z-index: -1;
-        }
-
-        /* Navbar */
-        .navbar {
-            background-color: #ffffff;
-            padding: 20px;
-            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-            position: fixed;
-            width: 100%;
-            top: 0;
-            z-index: 1000;
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-        }
-
-        .navbar a {
-            color: #333;
-            text-decoration: none;
-            margin: 0 15px;
-            font-size: 1.1em;
-            font-weight: 600;
-            transition: color 0.3s ease;
-        }
-
-        .navbar a:hover {
-            color: #007BFF;
-        }
-
-        /* Hero Section */
-        .hero {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            height: 100vh;
-            background-color: #e8eaf6;
-            text-align: center;
-            padding: 0 20px;
-            position: relative;
-        }
-
-        .hero h1 {
-            font-size: 3em;
-            color: #333;
-            font-weight: 800;
-            margin-bottom: 20px;
-        }
-
-        /* Section Styling */
-        .section {
-            padding: 60px 20px;
-            text-align: left;
-            max-width: 1100px;
-            margin: 0 auto;
-            background-color: #f4f4f9;
-        }
-
-        .section h2 {
-            font-size: 2.2em;
-            color: #333;
-            margin-bottom: 20px;
-            font-weight: 800;
-        }
-
-        .section p {
-            font-size: 1.1em;
-            color: #666;
-            margin-bottom: 20px;
-        }
-
-        .section ol {
-            list-style-position: inside;
-            margin-bottom: 20px;
-        }
-
-        .section ol li {
-            margin-bottom: 15px;
-        }
-
-        /* Footer */
-        .footer {
-            background-color: #333;
-            color: #ffffff;
-            padding: 40px 20px;
-            text-align: center;
-        }
-
-        .footer a {
-            color: #ffffff;
-            text-decoration: none;
-            margin: 0 10px;
-            font-size: 1.1em;
-        }
-
-        .footer a:hover {
-            color: #007BFF;
-        }
-
-        .footer p {
-            font-size: 0.9em;
-            margin-top: 20px;
-        }
-
-        /* Background color shift for visibility after first scroll */
-        .section.scrolled {
-            background-color: #ffffff;
-            padding: 100px 20px;
-            margin-top: 0;
-        }
-
-    </style>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Privacy Policy - Populi Advocātiō</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../style.css">
 </head>
 <body>
-
-    <!-- Particle.js Background -->
-    <div id="particles-js"></div>
-
-    <!-- Navbar -->
-    <div class="navbar">
-        <div>
-            <a href="https://apgo.ink">Home</a>
-            <a href="https://apgo.ink/tos" target="_blank">Terms of Service</a>
-            <a href="https://apgo.ink/contactus" target="_blank">Contact</a>
-        </div>
+  <nav>
+    <div class="logo"><a href="../" style="color:inherit;text-decoration:none">Populi Advocātiō</a></div>
+    <div class="links">
+      <a href="../">Home</a>
+      <a href="../tos" target="_blank">Terms</a>
+      <a href="../contactus" target="_blank">Contact</a>
+      <button class="theme-toggle">Toggle Theme</button>
     </div>
-
-    <!-- Hero Section -->
-    <div class="hero">
-        <div>
-            <h1>Privacy Policy</h1>
-        </div>
-    </div>
-
-    <!-- Privacy Policy Content -->
-    <section class="section scrolled">
-        <h2>1. Introduction</h2>
-        <p>At Populi Advocātiō, your privacy is of utmost importance to us. We are committed to protecting your personal information and ensuring a safe and secure experience while using our resources. This Privacy Policy outlines our practices and policies regarding data collection, usage, and protection.</p>
-
-        <h2>2. No Collection of Personal Information</h2>
-        <p>Populi Advocātiō does not collect, store, or process any personal information from our users. We believe that your privacy is a fundamental right, and as such, we do not engage in any form of data collection. Our focus is solely on providing you with valuable, well-researched resources in the fields of finance, geopolitics, and journalism.</p>
-        <ol>
-            <li>No Accounts or Profiles: We do not require you to create an account, profile, or provide any personal details to access our resources.</li>
-            <li>No Tracking or Analytics: We do not use tracking mechanisms, cookies, or analytics tools that gather personal data. Your activity on our platform remains anonymous and private.</li>
-        </ol>
-
-        <h2>3. Use of Cloudflare Services</h2>
-        <p>While we do not collect any personal information, please be aware that Populi Advocātiō uses Cloudflare services to enhance the security and performance of our website. Cloudflare may process limited technical data (such as IP addresses) as part of its service, but this is outside of our control and is governed by Cloudflare’s own privacy practices.</p>
-        <ol>
-            <li>Cloudflare’s Role: Cloudflare acts as a content delivery network (CDN) and provides security measures to protect our website from malicious activities. Any data processed by Cloudflare is subject to their privacy policy, not ours.</li>
-            <li>Your Privacy: We emphasize that we do not have access to any data that may be processed by Cloudflare. Populi Advocātiō does not use, store, or share any personal information.</li>
-        </ol>
-
-        <h2>4. Focus on Resource Delivery</h2>
-        <p>Our mission at Populi Advocātiō is to deliver rich, reliable, and well-researched resources to our users. We do not require any personal information to fulfill this mission. Our content is freely accessible, and our focus remains on providing valuable insights in finance, geopolitics, and journalism.</p>
-        <ol>
-            <li>Transparency: We maintain full transparency in our operations and are committed to upholding the highest standards of integrity and trust.</li>
-            <li>No Third-Party Sharing: Since we do not collect personal information, there is nothing to share with third parties. Your privacy is fully respected.</li>
-        </ol>
-
-        <h2>5. Changes to This Policy</h2>
-        <p>Populi Advocātiō reserves the right to update or modify this Privacy Policy at any time. Any changes will be reflected on this page, and the date of the latest update will be indicated at the bottom of the policy. We encourage you to review this policy periodically to stay informed about how we are protecting your privacy.</p>
-
-        <h2>6. Contact Information</h2>
-        <p>If you have any questions or concerns about this Privacy Policy, or if you need further information, please contact us at @ave.33 on Signal. We are here to address any issues you may have and ensure that your experience with Populi Advocātiō remains secure and private.</p>
-    </section>
-
-    <!-- Footer -->
-    <div class="footer">
-        <a href="https://apgo.ink/donation" target="_blank">Donate</a>
-        <a href="https://apgo.ink/tos" target="_blank">Terms of Service</a>
-        <a href="https://apgo.ink/contactus" target="_blank">Contact Us</a>
-        <p>&copy; 2024 Populi Advocātiō. All rights reserved.</p>
-    </div>
-
-    <!-- JavaScript -->
-    <script>
-        // Particles.js background decoration
-        particlesJS('particles-js', {
-            "particles": {
-                "number": {
-                    "value": 80,
-                    "density": {
-                        "enable": true,
-                        "value_area": 800
-                    }
-                },
-                "color": {
-                    "value": "#ffffff"
-                },
-                "shape": {
-                    "type": "circle",
-                    "stroke": {
-                        "width": 0,
-                        "color": "#000000"
-                    }
-                },
-                "opacity": {
-                    "value": 0.5,
-                    "random": false
-                },
-                "size": {
-                    "value": 5,
-                    "random": true
-                },
-                "line_linked": {
-                    "enable": true,
-                    "distance": 150,
-                    "color": "#ffffff",
-                    "opacity": 0.4,
-                    "width": 1
-                },
-                "move": {
-                    "enable": true,
-                    "speed": 6,
-                    "direction": "none",
-                    "random": false,
-                    "straight": false,
-                    "out_mode": "out",
-                    "bounce": false,
-                    "attract": {
-                        "enable": false,
-                        "rotateX": 600,
-                        "rotateY": 1200
-                    }
-                }
-            },
-            "retina_detect": true
-        });
-    </script>
-
+  </nav>
+  <section class="hero">
+    <h1>Privacy Policy</h1>
+  </section>
+  <section class="section fade-up">
+    <h2>1. Introduction</h2>
+    <p>At Populi Advocātiō, your privacy is of utmost importance. This policy outlines our practices regarding data collection and usage.</p>
+    <h2>2. No Collection of Personal Information</h2>
+    <p>We do not collect, store or process personal information. No accounts, profiles or tracking analytics are used on our platform.</p>
+    <h2>3. Use of Cloudflare Services</h2>
+    <p>We utilize Cloudflare to enhance security and performance. Limited technical data may be processed under Cloudflare's privacy policy.</p>
+    <h2>4. Focus on Resource Delivery</h2>
+    <p>Our mission is to deliver reliable, well-researched resources. We share nothing with third parties.</p>
+    <h2>5. Changes to This Policy</h2>
+    <p>We may update this policy from time to time. Revisit this page to stay informed of any changes.</p>
+    <h2>6. Contact Information</h2>
+    <p>For questions about this policy please contact us via Signal @ave.33.</p>
+  </section>
+  <footer>
+    <a href="../donation" target="_blank">Donate</a>
+    <a href="../tos" target="_blank">Terms of Service</a>
+    <a href="../contactus" target="_blank">Contact Us</a>
+    <p>&copy; 2024 Populi Advocātiō. All rights reserved.</p>
+  </footer>
+  <script src="../theme.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,136 @@
+/* Main theme styles */
+:root {
+  --background: #0d1117;   /* dark background */
+  --foreground: #c9d1d9;   /* light text */
+  --accent: #58a6ff;       /* bright blue accent */
+  --background-light: #ffffff;
+  --foreground-light: #1a1a1a;
+  --secondary: #8b949e;
+}
+body.light {
+  --background: var(--background-light);
+  --foreground: var(--foreground-light);
+}
+html, body {
+  padding: 0;
+  margin: 0;
+  background: var(--background);
+  color: var(--foreground);
+  font-family: 'Inter', 'Poppins', sans-serif;
+  scroll-behavior: smooth;
+}
+nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  backdrop-filter: blur(4px);
+  background: rgba(13,17,23,0.8);
+  z-index: 1000;
+}
+nav a {
+  color: var(--foreground);
+  text-decoration: none;
+  margin: 0 1rem;
+  font-weight: 600;
+}
+nav a:hover {
+  color: var(--accent);
+}
+.theme-toggle {
+  cursor: pointer;
+  border: none;
+  background: var(--accent);
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+}
+.hero {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  min-height: 90vh;
+  background: linear-gradient(135deg,#0a84ff,#5a189a);
+  color: #fff;
+  animation: fadeIn 1s ease-out;
+}
+.hero h1 {
+  font-size: 3.5rem;
+  margin-bottom: 1rem;
+}
+.hero p {
+  font-size: 1.2rem;
+  max-width: 700px;
+}
+.section {
+  padding: 4rem 1rem;
+  text-align: center;
+}
+.section h2 {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+}
+.cards {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1.5rem;
+}
+.card {
+  background: rgba(255,255,255,0.05);
+  border-radius: 8px;
+  box-shadow: 0 4px 10px rgba(0,0,0,0.2);
+  padding: 2rem;
+  width: 280px;
+  transition: transform .3s;
+}
+.card:hover {
+  transform: translateY(-6px);
+}
+.resource-card {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  background: rgba(255,255,255,0.05);
+  padding: 1rem;
+  border-radius: 8px;
+  margin: 0.5rem 0;
+  color: var(--foreground);
+  text-decoration: none;
+}
+.resource-card img,
+.resource-card .icon-box {
+  width: 60px;
+  height: 60px;
+  border-radius: 8px;
+  object-fit: cover;
+}
+footer {
+  background: #161b22;
+  color: var(--foreground);
+  text-align: center;
+  padding: 2rem 1rem;
+}
+footer a {
+  color: var(--accent);
+  margin: 0 1rem;
+  text-decoration: none;
+}
+@keyframes fadeIn {
+  from {opacity: 0; transform: translateY(10px);} to {opacity: 1; transform: translateY(0);}
+}
+
+/* simple fade-up animation for sections */
+.fade-up {
+  opacity: 0;
+  transform: translateY(20px);
+  animation: fadeUp 0.8s forwards;
+}
+@keyframes fadeUp {
+  to { opacity: 1; transform: translateY(0); }
+}

--- a/theme.js
+++ b/theme.js
@@ -1,0 +1,14 @@
+(function(){
+  const stored = localStorage.getItem('theme');
+  if(stored === 'light') document.body.classList.add('light');
+  document.addEventListener('DOMContentLoaded', () => {
+    const btn = document.querySelector('.theme-toggle');
+    if(btn){
+      btn.addEventListener('click', () => {
+        document.body.classList.toggle('light');
+        const mode = document.body.classList.contains('light') ? 'light' : 'dark';
+        localStorage.setItem('theme', mode);
+      });
+    }
+  });
+})();

--- a/tos/index.html
+++ b/tos/index.html
@@ -1,288 +1,53 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Terms of Service - Populi Advocātiō</title>
-
-    <!-- Google Fonts -->
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
-
-    <!-- Import particles.js for background decoration -->
-    <script src="https://cdn.jsdelivr.net/particles.js/2.0.0/particles.min.js"></script>
-
-    <style>
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
-
-        body {
-            font-family: 'Inter', sans-serif;
-            background-color: #f4f4f9;
-            color: #333;
-            line-height: 1.6;
-            margin: 0;
-            padding: 0;
-            scroll-behavior: smooth;
-            position: relative;
-            overflow-x: hidden;
-        }
-
-        /* Particle.js Background */
-        #particles-js {
-            position: fixed;
-            top: 100vh;
-            width: 100%;
-            height: 100vh;
-            z-index: -1;
-        }
-
-        /* Navbar */
-        .navbar {
-            background-color: #ffffff;
-            padding: 20px;
-            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-            position: fixed;
-            width: 100%;
-            top: 0;
-            z-index: 1000;
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-        }
-
-        .navbar a {
-            color: #333;
-            text-decoration: none;
-            margin: 0 15px;
-            font-size: 1.1em;
-            font-weight: 600;
-            transition: color 0.3s ease;
-        }
-
-        .navbar a:hover {
-            color: #007BFF;
-        }
-
-        /* Hero Section */
-        .hero {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            height: 100vh;
-            background-color: #e8eaf6;
-            text-align: center;
-            padding: 0 20px;
-            position: relative;
-        }
-
-        .hero h1 {
-            font-size: 3em;
-            color: #333;
-            font-weight: 800;
-            margin-bottom: 20px;
-        }
-
-        /* Section Styling */
-        .section {
-            padding: 60px 20px;
-            text-align: left;
-            max-width: 1100px;
-            margin: 0 auto;
-            background-color: #f4f4f9;
-        }
-
-        .section h2 {
-            font-size: 2.2em;
-            color: #333;
-            margin-bottom: 20px;
-            font-weight: 800;
-        }
-
-        .section p {
-            font-size: 1.1em;
-            color: #666;
-            margin-bottom: 20px;
-        }
-
-        .section ol {
-            list-style-position: inside;
-            margin-bottom: 20px;
-        }
-
-        .section ol li {
-            margin-bottom: 15px;
-        }
-
-        /* Footer */
-        .footer {
-            background-color: #333;
-            color: #ffffff;
-            padding: 40px 20px;
-            text-align: center;
-        }
-
-        .footer a {
-            color: #ffffff;
-            text-decoration: none;
-            margin: 0 10px;
-            font-size: 1.1em;
-        }
-
-        .footer a:hover {
-            color: #007BFF;
-        }
-
-        .footer p {
-            font-size: 0.9em;
-            margin-top: 20px;
-        }
-
-        /* Background color shift for visibility after first scroll */
-        .section.scrolled {
-            background-color: #ffffff;
-            padding: 100px 20px;
-            margin-top: 0;
-        }
-
-    </style>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Terms of Service - Populi Advocātiō</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../style.css">
 </head>
 <body>
-
-    <!-- Particle.js Background -->
-    <div id="particles-js"></div>
-
-    <!-- Navbar -->
-    <div class="navbar">
-        <div>
-            <a href="https://apgo.ink">Home</a>
-            <a href="https://apgo.ink/pp" target="_blank">Privacy Policy</a>
-            <a href="https://apgo.ink/contactus" target="_blank">Contact</a>
-        </div>
+  <nav>
+    <div class="logo"><a href="../" style="color:inherit;text-decoration:none">Populi Advocātiō</a></div>
+    <div class="links">
+      <a href="../">Home</a>
+      <a href="../pp" target="_blank">Privacy</a>
+      <a href="../contactus" target="_blank">Contact</a>
+      <button class="theme-toggle">Toggle Theme</button>
     </div>
-
-    <!-- Hero Section -->
-    <div class="hero">
-        <div>
-            <h1>Terms of Service</h1>
-        </div>
-    </div>
-
-    <!-- Terms of Service Content -->
-    <section class="section scrolled">
-        <h2>1. Introduction</h2>
-        <p>Welcome to Populi Advocātiō. By accessing, downloading, or using any of the resources, information, or data provided on this website, you agree to comply with and be bound by the following Terms of Service. These terms govern your use of our materials, and it is crucial that you read them carefully. If you do not agree to these terms, you must refrain from using our resources.</p>
-
-        <h2>2. About Us</h2>
-        <p>Populi Advocātiō is a dedicated organization based in Aargau, Switzerland, specializing in finance, geopolitics, and journalism. Our mission is to produce and provide well-researched, thoroughly assessed, and professionally curated content in these critical areas. We are committed to upholding the highest standards of transparency, accuracy, and integrity in all our work.</p>
-
-        <h2>3. Use of Resources</h2>
-        <p>The resources, information, and data available on Populi Advocātiō’s platform are intended for educational and informational purposes. You agree to use these materials responsibly and in accordance with the following guidelines:</p>
-        <ol>
-            <li>Permitted Use: You may access, download, use, and share our content freely for both personal and commercial purposes under an irrevocable, universal license for public use. Attribution to Populi Advocātiō is not mandatory but highly appreciated.</li>
-            <li>Prohibited Use: While our content is freely available, you are prohibited from:
-                <ul>
-                    <li>Misrepresentation: Altering or modifying our content in a way that misrepresents the original information or misleads others.</li>
-                    <li>Unlawful Use: Using our resources to promote illegal activities, misinformation, hate speech, or any content that could cause harm.</li>
-                </ul>
-            </li>
-        </ol>
-
-        <h2>4. Professional Standards</h2>
-        <p>Populi Advocātiō adheres to the highest standards of professionalism and accuracy. The content we provide is the result of rigorous research, assessment, and verification processes. Our commitment to these standards ensures that the information you receive is reliable and trustworthy.</p>
-        <ol>
-            <li>Research Integrity: All data, analyses, and reports provided by Populi Advocātiō are based on comprehensive research and sourced from credible, verifiable origins. We prioritize factual accuracy and objectivity in all our work.</li>
-            <li>Transparency: We are fully transparent with our methodologies and sources. Each piece of content includes citations and references where applicable, allowing users to trace the information back to its original source.</li>
-        </ol>
-
-        <h2>5. Intellectual Property Rights</h2>
-        <p>Populi Advocātiō’s content is provided under an irrevocable license for public use. This means you are free to use, modify, distribute, and build upon our content for any purpose, provided you adhere to the restrictions outlined in these terms.</p>
-        <ol>
-            <li>License: Our content is freely available for use by anyone, without restrictions, except as noted. Attribution is not required but is greatly appreciated.</li>
-            <li>Restrictions: You may not modify our content in a manner that misrepresents the original information or leads to misinformation. Any such misuse of our content is strictly prohibited.</li>
-        </ol>
-
-        <h2>6. Disclaimer of Warranties</h2>
-        <p>Populi Advocātiō provides all resources, information, and data on an "as is" basis without warranties of any kind, either express or implied. While our content is meticulously analyzed, we strongly advise users to conduct their own research and cross-reference our findings with other sources for their own understanding and decision-making.</p>
-
-        <h2>7. Limitation of Liability</h2>
-        <p>In no event shall Populi Advocātiō, its affiliates, or its contributors be liable for any direct, indirect, incidental, or consequential damages arising from the use of, or inability to use, our resources, information, or data. This limitation of liability applies to all users, regardless of the legal theory under which such liability is asserted.</p>
-
-        <h2>8. Changes to the Terms</h2>
-        <p>Populi Advocātiō reserves the right to modify or update these Terms of Service at any time without prior notice. Any changes will be effective immediately upon posting on our website. Your continued use of our resources following the posting of revised terms constitutes your acceptance of those changes.</p>
-
-        <h2>9. Governing Law</h2>
-        <p>These Terms of Service shall be governed by and construed in accordance with the laws of Switzerland, specifically the canton of Aargau, without regard to its conflict of law principles. Any disputes arising under these terms shall be resolved exclusively by the courts located in Aargau, Switzerland.</p>
-
-        <h2>10. Contact Information</h2>
-        <p>If you have any questions, concerns, or requests related to these Terms of Service, please contact us at @ave.33 on Signal. We are committed to addressing your inquiries in a timely and professional manner.</p>
-    </section>
-
-    <!-- Footer -->
-    <div class="footer">
-        <a href="https://apgo.ink/donation" target="_blank">Donate</a>
-        <a href="https://apgo.ink/pp" target="_blank">Privacy Policy</a>
-        <a href="https://apgo.ink/contactus" target="_blank">Contact Us</a>
-        <p>&copy; 2024 Populi Advocātiō. All rights reserved.</p>
-    </div>
-
-    <!-- JavaScript -->
-    <script>
-        // Particles.js background decoration
-        particlesJS('particles-js', {
-            "particles": {
-                "number": {
-                    "value": 80,
-                    "density": {
-                        "enable": true,
-                        "value_area": 800
-                    }
-                },
-                "color": {
-                    "value": "#ffffff"
-                },
-                "shape": {
-                    "type": "circle",
-                    "stroke": {
-                        "width": 0,
-                        "color": "#000000"
-                    }
-                },
-                "opacity": {
-                    "value": 0.5,
-                    "random": false
-                },
-                "size": {
-                    "value": 5,
-                    "random": true
-                },
-                "line_linked": {
-                    "enable": true,
-                    "distance": 150,
-                    "color": "#ffffff",
-                    "opacity": 0.4,
-                    "width": 1
-                },
-                "move": {
-                    "enable": true,
-                    "speed": 6,
-                    "direction": "none",
-                    "random": false,
-                    "straight": false,
-                    "out_mode": "out",
-                    "bounce": false,
-                    "attract": {
-                        "enable": false,
-                        "rotateX": 600,
-                        "rotateY": 1200
-                    }
-                }
-            },
-            "retina_detect": true
-        });
-    </script>
-
+  </nav>
+  <section class="hero">
+    <h1>Terms of Service</h1>
+  </section>
+  <section class="section fade-up">
+    <h2>1. Introduction</h2>
+    <p>By accessing or using our resources you agree to these Terms of Service. Please read them carefully.</p>
+    <h2>2. About Us</h2>
+    <p>Populi Advocātiō is a Switzerland-based organization specializing in finance, geopolitics and journalism.</p>
+    <h2>3. Use of Resources</h2>
+    <p>Our content is provided under an irrevocable universal license for public use. Misrepresentation or unlawful use is prohibited.</p>
+    <h2>4. Professional Standards</h2>
+    <p>All information is thoroughly researched and sourced from credible origins.</p>
+    <h2>5. Intellectual Property Rights</h2>
+    <p>Attribution is appreciated though not required. Do not misrepresent our content.</p>
+    <h2>6. Disclaimer of Warranties</h2>
+    <p>All resources are provided "as is" without warranties of any kind. Cross-reference our findings for your own understanding.</p>
+    <h2>7. Limitation of Liability</h2>
+    <p>Populi Advocātiō shall not be liable for any damages arising from use of our resources.</p>
+    <h2>8. Changes to the Terms</h2>
+    <p>We may update these terms without notice. Continued use constitutes acceptance of any changes.</p>
+    <h2>9. Governing Law</h2>
+    <p>These terms are governed by the laws of Switzerland, canton of Aargau.</p>
+    <h2>10. Contact Information</h2>
+    <p>For inquiries please reach us via Signal @ave.33.</p>
+  </section>
+  <footer>
+    <a href="../donation" target="_blank">Donate</a>
+    <a href="../pp" target="_blank">Privacy Policy</a>
+    <a href="../contactus" target="_blank">Contact Us</a>
+    <p>&copy; 2024 Populi Advocātiō. All rights reserved.</p>
+  </footer>
+  <script src="../theme.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- refresh homepage with a modern dark layout
- add light/dark theme toggle via JavaScript
- restyle donation, privacy policy, and terms of service pages
- share common CSS and script across pages

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683f69743f308327891b041864728004